### PR TITLE
FIX: diversity matching at 0.0

### DIFF
--- a/scripts/describe_dataset.ipynb
+++ b/scripts/describe_dataset.ipynb
@@ -27,6 +27,7 @@
         "\n",
         "from src.utils import extract_color\n",
         "from src.display_meta import display_diet_information\n",
+        "from src.viz_alpha_div import read_and_prep_abx_exposure_data\n",
         "\n",
         "%load_ext autoreload\n",
         "%autoreload 2\n",
@@ -83,9 +84,7 @@
       "outputs": [],
       "source": [
         "# read and prep abx exposure data\n",
-        "abx_df = pd.read_csv(path_to_abx, sep=\"\\t\")\n",
-        "ls_abx_cols = [\"host_id\", \"abx_start_age_months\"]\n",
-        "abx_df = abx_df[ls_abx_cols].sort_values(ls_abx_cols).drop_duplicates()"
+        "abx_df = read_and_prep_abx_exposure_data(path_to_abx)"
       ]
     },
     {
@@ -704,7 +703,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "infant-meta",
+      "display_name": "preprocess_microbiome",
       "language": "python",
       "name": "python3"
     },

--- a/scripts/describe_matched_alpha.ipynb
+++ b/scripts/describe_matched_alpha.ipynb
@@ -16,7 +16,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -47,7 +47,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -61,7 +61,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -84,7 +84,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -326,7 +326,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [


### PR DESCRIPTION
this PR adjusts "matching alpha diversity" after abx exposure to comparable set-up as in ["score evaluation" after abx exposure](https://github.com/MarkusChardonnet/Probabilistic_forecasting_for_Anomaly_Detection/blob/main/results/evaluate_scores.ipynb). 

It introduces:
* fix that diversity metrics at 0.0 are not prior to abx exposure
* fix of host with wrongly depicted age at abx start